### PR TITLE
[demo-2]Turbo Framesを使って一覧部分を読み込む

### DIFF
--- a/hotwire-tw-demo/app/views/emotions/_new.html.erb
+++ b/hotwire-tw-demo/app/views/emotions/_new.html.erb
@@ -9,7 +9,7 @@
       </ul>
     </div>
   <% end %>
-  <%= form_with model: @emotion || Emotion.new do |form| %>
+  <%= form_with model: @emotion || Emotion.new, data: { turbo_frame: "emotions" } do |form| %>
     <div class="mb-3 row">
       <%= form.label :icon, "きもち", class: "col-sm-2 col-form-label" %>
       <div class="col-sm-10">

--- a/hotwire-tw-demo/app/views/emotions/index.html.erb
+++ b/hotwire-tw-demo/app/views/emotions/index.html.erb
@@ -3,5 +3,7 @@
 </div>
 
 <ol class="emotion-list w-100">
-  <%= render partial: "emotion", collection: @emotions %>
+  <%= turbo_frame_tag "emotions" do %>
+    <%= render partial: "emotion", collection: @emotions %>
+  <% end %>
 </ol>

--- a/hotwire-tw-demo/app/views/layouts/_sidebar.html.erb
+++ b/hotwire-tw-demo/app/views/layouts/_sidebar.html.erb
@@ -12,19 +12,19 @@
       <% end %>
     </li>
     <li>
-      <%= link_to root_path(icon: Emotion.icons[:love]), class: "nav-link #{active_css_class(root_path + "?icon=0")}" do %>
+      <%= link_to root_path(icon: Emotion.icons[:love]), class: "nav-link #{active_css_class(root_path + "?icon=0")}", data: { turbo_frame: "emotions" } do %>
         <%== show_icon(Emotion.icons[:love], width: 30, height: 30) %>
       <% end %>
     </li>
     <li>
-      <%= link_to root_path(icon: Emotion.icons[:angry]), class: "nav-link #{active_css_class(root_path + "?icon=1")}" do %>
+      <%= link_to root_path(icon: Emotion.icons[:angry]), class: "nav-link #{active_css_class(root_path + "?icon=1")}", data: { turbo_frame: "emotions" } do %>
         <span class="nav-icon">
         <%== show_icon(Emotion.icons[:angry], width: 30, height: 30) %>
         </span>
       <% end %>
     </li>
     <li>
-      <%= link_to root_path(icon: Emotion.icons[:smile]), class: "nav-link #{active_css_class(root_path + "?icon=2")}" do %>
+      <%= link_to root_path(icon: Emotion.icons[:smile]), class: "nav-link #{active_css_class(root_path + "?icon=2")}", data: { turbo_frame: "emotions" } do %>
         <span class="nav-icon">
         <%== show_icon(Emotion.icons[:smile], width: 30, height: 30) %>
         </span>


### PR DESCRIPTION
## やったこと
- Tweet一覧部分をTurbo Framesを使って読み込む
  - 更新したい一覧部分を`<%= turbo_frame_tag "emotions" do %>`で囲む
  - 更新のトリガーにしたいフォームとリンクに`data: { turbo_frame: "emotions" }`属性をつける

<img width="1251" alt="frame-emotions" src="https://user-images.githubusercontent.com/545535/207085179-7f149650-9bed-47a8-8633-ee635b89b497.png">


### 確認
- turbo-frame のidが付与されている
- フォームに入力したままサイドバーの切り替えをしてフォームの内容が残る

## できなくなったこと

フォームのエラー表示

## 公式ドキュメント

[Turbo Reference:Frames](https://turbo.hotwired.dev/reference/frames)

[Turbo Handbook:Decompose with Turbo Frames](https://turbo.hotwired.dev/handbook/frames)