### PR TITLE
[demo-4]	WebSocketを使ったブロードキャスト方式に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,12 @@ services:
       - db-store:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=passw0rd
+  redis:
+    image: redis:latest
+    restart: always
+    ports:
+      - '6379:6379'
+    volumes:
+     - "./data/redis:/data"
 volumes:
   db-store:

--- a/hotwire-tw-demo/app/models/emotion.rb
+++ b/hotwire-tw-demo/app/models/emotion.rb
@@ -8,5 +8,7 @@ class Emotion < ApplicationRecord
     update!(like_count: like_count + 1)
   end
 
+  # NOTE: broadcasts_to -> (_emotion) { "emotions" }, inserts_by: :prepend でも代用可
   after_create_commit -> { broadcast_prepend_to("emotions") }
+  after_destroy_commit -> { broadcast_remove_to("emotions") }
 end

--- a/hotwire-tw-demo/app/models/emotion.rb
+++ b/hotwire-tw-demo/app/models/emotion.rb
@@ -7,4 +7,6 @@ class Emotion < ApplicationRecord
   def like_countup!
     update!(like_count: like_count + 1)
   end
+
+  after_create_commit -> { broadcast_prepend_to("emotions") }
 end

--- a/hotwire-tw-demo/app/models/emotion.rb
+++ b/hotwire-tw-demo/app/models/emotion.rb
@@ -1,14 +1,15 @@
 class Emotion < ApplicationRecord
+  enum :icon, { love: 0, angry: 1, smile: 2 }
+
   validates :name, presence: true
   validates :body, presence: true
   validates :icon, presence: true
-  enum :icon, { love: 0, angry: 1, smile: 2 }
-
-  def like_countup!
-    update!(like_count: like_count + 1)
-  end
 
   # NOTE: broadcasts_to -> (_emotion) { "emotions" }, inserts_by: :prepend でも代用可
   after_create_commit -> { broadcast_prepend_to("emotions") }
   after_destroy_commit -> { broadcast_remove_to("emotions") }
+
+  def like_countup!
+    update!(like_count: like_count + 1)
+  end
 end

--- a/hotwire-tw-demo/app/views/emotions/_emotion.html.erb
+++ b/hotwire-tw-demo/app/views/emotions/_emotion.html.erb
@@ -1,27 +1,29 @@
-<li class="emotion-card">
-  <div class="emotion-content">
-    <div class="emotion-header">
-      <span class="fullname">
-        <strong><%= emotion.name %></strong>
-      </span>
-      <span class="emotion-time">
-        <%= link_to "- #{l(emotion.created_at, format: :date)}", emotion_path(emotion) %>
-      </span>
+<%= turbo_frame_tag emotion do %>
+  <li class="emotion-card">
+    <div class="emotion-content">
+      <div class="emotion-header">
+        <span class="fullname">
+          <strong><%= emotion.name %></strong>
+        </span>
+        <span class="emotion-time">
+          <%= link_to "- #{l(emotion.created_at, format: :date)}", emotion_path(emotion) %>
+        </span>
+      </div>
+      <div class="emotion-card-avatar">
+        <%== show_icon(Emotion.icons[emotion.icon]) %>
+      </div>
+      <div class="emotion-text">
+        <p> <%= simple_format emotion.body %> </p>
+      </div>
+      <div class="emotion-footer">
+        <%= button_to like_emotion_path(emotion), method: :put, class: "emotion-footer-btn" do %>
+          <svg class="bi me-2" width="20" height="20"><use xlink:href="#balloon-heart-fill"/></svg><span><%=emotion.like_count %></span>
+        <% end %>
+        <%= button_to emotion, method: :delete, class: "emotion-footer-btn" do %>
+          <svg class="bi me-2" width="20" height="20"><use xlink:href="#trash-fill"/></svg>
+          <span>削除</span>
+        <% end %>
+      </div>
     </div>
-    <div class="emotion-card-avatar">
-      <%== show_icon(Emotion.icons[emotion.icon]) %>
-    </div>
-    <div class="emotion-text">
-      <p> <%= simple_format emotion.body %> </p>
-    </div>
-    <div class="emotion-footer">
-      <%= button_to like_emotion_path(emotion), method: :put, class: "emotion-footer-btn" do %>
-        <svg class="bi me-2" width="20" height="20"><use xlink:href="#balloon-heart-fill"/></svg><span><%=emotion.like_count %></span>
-      <% end %>
-      <%= button_to emotion, method: :delete, class: "emotion-footer-btn" do %>
-        <svg class="bi me-2" width="20" height="20"><use xlink:href="#trash-fill"/></svg>
-        <span>削除</span>
-      <% end %>
-    </div>
-  </div>
-</li>
+  </li>
+<% end %>

--- a/hotwire-tw-demo/app/views/emotions/create.turbo_stream.erb
+++ b/hotwire-tw-demo/app/views/emotions/create.turbo_stream.erb
@@ -4,10 +4,3 @@
 <%= turbo_stream.replace "emotion_form" do %>
   <%= render partial: "new", locals: {emotion: @emotion.persisted? ? Emotion.new : @emotion} %>
 <% end %>
-<% if @emotion.persisted? %>
-  <%= turbo_stream.prepend "emotions" do %>
-    <li class="emotion-card">
-      <%= render partial: "emotion", locals: {emotion: @emotion} %>
-    </li>
-  <% end %>
-<% end %>

--- a/hotwire-tw-demo/app/views/emotions/index.html.erb
+++ b/hotwire-tw-demo/app/views/emotions/index.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_stream_from "emotions" %>
 <div id="flash">
 </div>
 <div class="p-3 border bg-ligh">


### PR DESCRIPTION
### やったこと

- Tweetの追加をブロードキャスト方式に
  - docker-compose にredisを追加
  - Emotionモデルに`after_create_commit -> { broadcast_prepend_to("emotions") }`によるブロードキャストを追加
  - index.html.erb にemotionsの変更をサブスクライブする`<%= turbo_stream_from "emotions" %>`を追加
  - create.turbo_stream.erbでの、emotion追加時のprependを削除
- 削除もそちらに対応
  - Emotionモデルに`after_destroy_commit -> { broadcast_remove_to("emotions") }`によるブロードキャストを追加
  - _emotion.html.erbで、内容を`<%= turbo_frame_tag emotion do %>`　で囲むことで各emotionに個別のidをもつturbo-frameタグを追加

### 確認方法

二つのブラウザをひらいて追加、削除をしてみて、別のブラウザで即時反映される