### PR TITLE
[demo-5]Stimulusを使ったイベントによるフォーム内容チェック

### DIFF
--- a/hotwire-tw-demo/app/javascript/controllers/emotions_controller.js
+++ b/hotwire-tw-demo/app/javascript/controllers/emotions_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "name", "body", "icon" ]
+
+  submit() {
+    const isAllInput = this.nameTarget.value !== "" &&
+     this.bodyTarget.value !== "" &&
+     this.iconTargets.some((icon) => { return icon.checked } )
+
+    if(isAllInput) {
+      this.element.requestSubmit()
+     } else {
+       alert("すべての項目を入力してください")
+       event.preventDefault()
+    }
+  }
+}

--- a/hotwire-tw-demo/app/javascript/controllers/index.js
+++ b/hotwire-tw-demo/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import EmotionsController from "./emotions_controller"
+application.register("emotions", EmotionsController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/hotwire-tw-demo/app/views/emotions/_new.html.erb
+++ b/hotwire-tw-demo/app/views/emotions/_new.html.erb
@@ -10,20 +10,20 @@
         </ul>
       </div>
     <% end %>
-    <%= form_with model: emotion, local: true do |form| %>
+    <%= form_with model: emotion, local: true, html: { data: {controller: "emotions", action: "emotions#submit"}, id: "form" } do |form| %>
       <div class="mb-3 row">
         <%= form.label :icon, "きもち", class: "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
-          <%= form.radio_button :icon, :love, class: "form-check-input" %>
+          <%= form.radio_button :icon, :love, class: "form-check-input", data: {emotions_target: "icon"} %>
           <%= form.label :icon, value: :love, class: "avator-icon" do %>
             <%== show_icon(Emotion.icons[:love]) %>
           <% end %>
-          <%= form.radio_button :icon, :angry, class: "form-check-input" %>
+          <%= form.radio_button :icon, :angry, class: "form-check-input", data: {emotions_target: "icon"} %>
           <%= form.label :icon, value: :angry, class: "avator-icon" do %>
             <%== show_icon(Emotion.icons[:angry]) %>
           <% end %>
 
-          <%= form.radio_button :icon, :smile, class: "form-check-input" %>
+          <%= form.radio_button :icon, :smile, class: "form-check-input", data: {emotions_target: "icon"} %>
           <%= form.label :icon, value: :smile, class: "avator-icon" do %>
             <%== show_icon(Emotion.icons[:smile]) %>
           <% end %>
@@ -32,13 +32,13 @@
       <div class="mb-3 row">
         <%= form.label :name, "なまえ", class: "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
-          <%= form.text_field :name, class: "form-contorol" %>
+          <%= form.text_field :name, class: "form-contorol", data: {emotions_target: "name"} %>
         </div>
       </div>
       <div class="mb-3 row">
         <%= form.label :body, "こころのこえ", class: "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
-          <%= form.text_area :body, class: "form-contorol col-sm-10" %>
+          <%= form.text_area :body, class: "form-contorol col-sm-10", data: {emotions_target: "body"} %>
         </div>
       </div>
       <%= form.submit 'つぶやく', class: "btn btn-primary" %>


### PR DESCRIPTION
### やったこと
- Stimulusを使って、フォームの内容が不十分であればSubmitイベントで警告を出してSubmitしない
  - emotions_controller.js　の追加
    - targets, actionの定義
  - index.jsでemotions_controller.jsの読み込み
  - _new.html.erb で、監視したいターゲット要素に`data: {コントローラ名_target: "ターゲット名"}`  （`data: {emotions_target: "name"}` が`data-emotions-target="name"`属性となる） を追加

### 確認方法
- フォームの入力を不十分なままサブミットする
<img width="1646" alt="image" src="https://user-images.githubusercontent.com/545535/207106233-59bd70b2-4485-40b3-941a-67fb689a5af3.png">

### 公式ドキュメント

[Stimulus Reference](https://stimulus.hotwired.dev/reference/controllers)

[Stimulus Handbook](https://stimulus.hotwired.dev/handbook/introduction)
