### PR TITLE
Railsの設定・起動に `bundle install` を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ docker-compose up -d
 ```
 $ cd hotwire-tw-demo
 $ yarn install
+$ bundle install
 $ bin/rails db:create db:migrate
 $ bin/dev
 ```


### PR DESCRIPTION
`bundle install` がないと `bin/rails db:create db:migrate` に失敗するため追加しました。